### PR TITLE
Add a publish flattened to give more flexibility in messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ class SQS {
    * @return {Promise}
    */
   publish(name, content, meta = {}, handle = true, options = {}) {
+    this.publishFlattened(name, { content }, meta, handle, options);
+  }
+
+  publishFlattened(name, content, meta = {}, handle = true, options = {}) {
     const queueUrl = this.queues[name];
     if (!queueUrl) {
       const error = new Error(`Queue ${name} does not exists`);
@@ -130,7 +134,7 @@ class SQS {
     }
     const params = {
       QueueUrl: this.queues[name],
-      MessageBody: JSON.stringify({ content, meta }),
+      MessageBody: JSON.stringify({ ...content, meta }),
     };
 
     if (typeof options.delay === 'number') {

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ class SQS {
     }
     const params = {
       QueueUrl: this.queues[name],
-      MessageBody: JSON.stringify({ ...content, meta }),
+      MessageBody: JSON.stringify({ ...content, meta: meta }),
     };
 
     if (typeof options.delay === 'number') {


### PR DESCRIPTION
1. The messages today go in as `{"content":<body>}`
2. We have utilities in services like sworkerv2 which require `"action"` to be in the root object.
3. Adding a publishFlattened to give clients more control over the message structure